### PR TITLE
IOSで共有ができないバグを修正

### DIFF
--- a/src/components/DetailPage.js
+++ b/src/components/DetailPage.js
@@ -29,7 +29,11 @@ export default class extends Component {
       options
     );
 
-    Sharing.shareAsync(shareImgSource).catch(() =>
+    const shareImgSourcePath = shareImgSource.match("file://")
+      ? shareImgSource
+      : `file://${shareImgSource}`;
+
+    Sharing.shareAsync(shareImgSourcePath).catch(() =>
       Alert.alert("共有に失敗しました")
     );
     this.setState({ loading: false });


### PR DESCRIPTION
file:// がデフォルトでは含まれない仕様らしい
sourceのpathに含まれてないときは付与するようにしたらsimulatorでは動いた

このブランチをプルして動作確認ができたらマージして
できなかったらslackでメンションして