### PR TITLE
add props for password

### DIFF
--- a/libs/components/Form.js
+++ b/libs/components/Form.js
@@ -39,6 +39,7 @@ export default ({
           placeholder={placeholder}
           editable={editable}
           keyboardType={keyboardType}
+          secureTextEntry={label.match(/パスワード/) ? true : false}
         />
         {setCurrentLocation && (
           <TouchableOpacity


### PR DESCRIPTION
`TextInput`のprops `secureTextEntry`をtrueにするとパスワードが伏せ字で入力されるようになって、キーボードも半角専用のが出てくるのをこっちで確認したので、Androidでも挙動確認して大丈夫そうならマージして〜

あとアカウント新規登録が絶対「メールアドレスはすでに使用されています」ってでるのはfirebase側の問題？？